### PR TITLE
InsertBefore and IinsertAfter functions for DOM manipulation

### DIFF
--- a/edom.js
+++ b/edom.js
@@ -149,3 +149,21 @@ const addEvent = element => (event, handler) => {
 const removeEvent = element => (event, handler) => {
    element.removeEventListener(event, handler);
 }
+
+/**
+ * Insert an element before another element
+ * @param {HTMLElement} newElement - The new element to be inserted
+ * @return {Function(referenceElement<HTMLElement>)} - The reference element before which the new element will be inserted
+ */
+const insertBefore = newElement => referenceElement => {
+   referenceElement.parentNode.insertBefore(newElement, referenceElement);
+}
+
+/**
+* Insert an element after another element
+* @param {HTMLElement} newElement - The new element to be inserted
+* @return {Function(referenceElement<HTMLElement>)} - The reference element after which the new element will be inserted
+*/
+const insertAfter = newElement => referenceElement => {
+   referenceElement.parentNode.insertBefore(newElement, referenceElement.nextSibling);
+}

--- a/edom.js
+++ b/edom.js
@@ -131,3 +131,21 @@ const loadScript = (src) => {
    setAttrTo(script)("src")(src);
    appendIn(document.body)(script);
 }
+
+/**
+ * Add event listener to an element
+ * @param   {HTMLElement} element
+ * @return   {Function(event<String>, handler<Function>)} specify the event type and the handler
+ */
+const addEvent = element => (event, handler) => {
+   element.addEventListener(event, handler);
+}
+
+/**
+* Remove event listener from an element
+* @param   {HTMLElement} element
+* @return   {Function(event<String>, handler<Function>)} specify the event type and the handler
+*/
+const removeEvent = element => (event, handler) => {
+   element.removeEventListener(event, handler);
+}


### PR DESCRIPTION
### Description des Modifications

J'ai ajouté deux nouvelles fonctions, `insertBefore` et `insertAfter`, pour faciliter la manipulation du DOM. Ces fonctions permettent d'insérer un élément HTML avant ou après un autre élément respectivement. Elles sont utiles pour la construction dynamique de l'interface utilisateur et peuvent contribuer à rendre le code plus lisible et modulaire.

### Détails des Modifications

- Ajout des fonctions `insertBefore` et `insertAfter` pour insérer un élément avant ou après un autre élément dans le DOM.
- Les fonctions prennent en charge deux arguments : le nouvel élément à insérer et l'élément de référence avant ou après lequel l'insertion doit être effectuée.
- Ces fonctions sont utiles pour les opérations de manipulation du DOM dans des scénarios où l'ordre des éléments est important.

### Exemple d'Utilisation

```javascript
const newElement = document.createElement('div');
const referenceElement = document.getElementById('referenceElement');

// Insérer newElement avant referenceElement
insertBefore(newElement)(referenceElement);

// Insérer newElement après referenceElement
insertAfter(newElement)(referenceElement);
